### PR TITLE
feat: capture environmentMetrics + powerMetrics via pubsub callback

### DIFF
--- a/scripts/meshmetricsd.py
+++ b/scripts/meshmetricsd.py
@@ -191,6 +191,12 @@ class MeshtasticTelemetryDaemon:
         self.running = False
         self.logger = None
         self.prometheus_exporter = None
+        # Cache for telemetry variants that meshtastic-python doesn't persist in
+        # interface.nodesByNum (environmentMetrics / powerMetrics / airQualityMetrics
+        # arrive via pubsub on every broadcast but are not stored per-node by the
+        # library). Indexed by from-node number; each value is a dict keyed by
+        # variant name with the latest payload.
+        self.telemetry_cache: Dict[int, Dict[str, Dict]] = {}
         self.stats = {
             'start_time': None,
             'last_poll': None,
@@ -435,6 +441,31 @@ class MeshtasticTelemetryDaemon:
 
         return devices
 
+    def _on_telemetry_recv(self, packet, interface):
+        """pubsub handler for incoming Meshtastic packets.
+
+        meshtastic-python persists deviceMetrics into nodesByNum but does NOT
+        persist environmentMetrics / powerMetrics / airQualityMetrics. We sniff
+        the raw stream and keep the latest payload per (node, variant) so the
+        normal poll path can pick them up.
+        """
+        try:
+            decoded = packet.get('decoded', {}) if isinstance(packet, dict) else {}
+            if decoded.get('portnum') != 'TELEMETRY_APP':
+                return
+            tel = decoded.get('telemetry', {})
+            from_node = packet.get('from')
+            if from_node is None:
+                return
+            node_cache = self.telemetry_cache.setdefault(from_node, {})
+            for variant in ('deviceMetrics', 'environmentMetrics', 'powerMetrics', 'airQualityMetrics'):
+                if variant in tel:
+                    node_cache[variant] = tel[variant]
+        except Exception as e:
+            # Never let a malformed packet kill the daemon
+            if self.logger:
+                self.logger.debug(f"Telemetry sniff error: {e}")
+
     def connect_to_meshtastic(self) -> bool:
         """Connect to Meshtastic device"""
         try:
@@ -448,6 +479,15 @@ class MeshtasticTelemetryDaemon:
             else:
                 self.logger.error(f"Invalid mode: {mode}")
                 return False
+
+            # Subscribe to incoming packets so we can capture variants the
+            # library doesn't cache (environment / power / air-quality).
+            try:
+                from pubsub import pub
+                pub.subscribe(self._on_telemetry_recv, 'meshtastic.receive')
+                self.logger.debug("Subscribed to meshtastic.receive for telemetry sniffing")
+            except ImportError:
+                self.logger.warning("pubsub not available — env/power metrics may be missed")
 
             self.logger.info(f"Connected to Meshtastic device via {mode} at {port}")
             return True
@@ -483,13 +523,23 @@ class MeshtasticTelemetryDaemon:
             
             # Wait a bit for response to arrive
             time.sleep(min(timeout, 15))  # Cap at 15 seconds to avoid blocking too long
-            
+
             # Check if we have fresh telemetry data
             node_info = self.interface.nodes.get(node_num, {})
-            
+
             # Also check the nodedb for updated info
             if hasattr(self.interface, 'nodesByNum') and node_num in self.interface.nodesByNum:
-                node_info = self.interface.nodesByNum[node_num]
+                node_info = dict(self.interface.nodesByNum[node_num])
+
+            # Merge variants we sniffed off the wire ourselves. The library
+            # persists deviceMetrics into nodesByNum at first sight and then
+            # leaves it stale (subsequent broadcasts don't update it);
+            # environmentMetrics / powerMetrics / airQualityMetrics never land
+            # there at all. The pubsub callback in _on_telemetry_recv keeps a
+            # fresh per-node copy of each variant — let it win over nodesByNum.
+            cached = self.telemetry_cache.get(node_num, {})
+            for variant, payload in cached.items():
+                node_info[variant] = payload
 
             # Extract telemetry data
             telemetry_data = {}
@@ -515,7 +565,25 @@ class MeshtasticTelemetryDaemon:
                     telemetry_data['humidity'] = env_metrics['relativeHumidity']
                 if 'barometricPressure' in env_metrics:
                     telemetry_data['pressure'] = env_metrics['barometricPressure']
-            
+
+            # Check for power metrics (INA219/INA226/INA260/INA3221 channels).
+            # Fields are emitted by the firmware only for channels the user wired,
+            # so each is gated independently.
+            if 'powerMetrics' in node_info:
+                power_metrics = node_info['powerMetrics']
+                if 'ch1Voltage' in power_metrics:
+                    telemetry_data['power_ch1_voltage'] = power_metrics['ch1Voltage']
+                if 'ch1Current' in power_metrics:
+                    telemetry_data['power_ch1_current'] = power_metrics['ch1Current']
+                if 'ch2Voltage' in power_metrics:
+                    telemetry_data['power_ch2_voltage'] = power_metrics['ch2Voltage']
+                if 'ch2Current' in power_metrics:
+                    telemetry_data['power_ch2_current'] = power_metrics['ch2Current']
+                if 'ch3Voltage' in power_metrics:
+                    telemetry_data['power_ch3_voltage'] = power_metrics['ch3Voltage']
+                if 'ch3Current' in power_metrics:
+                    telemetry_data['power_ch3_current'] = power_metrics['ch3Current']
+
             if telemetry_data:
                 self.logger.debug(f"Collected telemetry from {node_id}: {list(telemetry_data.keys())}")
             else:


### PR DESCRIPTION
## Summary

The daemon currently only reads `interface.nodesByNum[node]` for telemetry extraction. meshtastic-python persists `deviceMetrics` there reliably but **does not** keep `environmentMetrics` or `powerMetrics` in that dict — those variants are dispatched through the pubsub `meshtastic.receive` topic and discarded if nothing subscribes. As a result, dashboards that depend on **INA219 / INA226 / INA260 / INA3221 / MAX17048** current readings (the PowerTelemetry variant) get no data at all, and environment metrics sometimes appear stale.

This adds three small pieces:

1. **`self.telemetry_cache`** on the daemon instance — keyed by from-node, with one slot per variant (`deviceMetrics` / `environmentMetrics` / `powerMetrics` / `airQualityMetrics`).
2. **`_on_telemetry_recv(packet, interface)`** — a pubsub handler that stashes the latest payload for each `(node, variant)` pair it sees. Registered via `pub.subscribe(...)` right after the serial / TCP interface comes up. Errors are caught so a malformed packet never kills the daemon.
3. In **`request_telemetry()`**, after the existing 15 s wait, the cache is merged on top of `nodesByNum[node]` with `node_info[v] = p` (override, not `setdefault` — `deviceMetrics` in `nodesByNum` is the first-broadcast snapshot and stays stale, the pubsub-sourced copy is the fresh one).

Six new Prometheus metrics are emitted when a node sends PowerMetrics (each gated independently because the firmware only fills channels the user has wired):

- `meshtastic_power_ch1_voltage`
- `meshtastic_power_ch1_current`
- `meshtastic_power_ch2_voltage`
- `meshtastic_power_ch2_current`
- `meshtastic_power_ch3_voltage`
- `meshtastic_power_ch3_current`

## Test plan

Validated end-to-end against a Nordic nRF54L15-DK running Meshtastic firmware 2.8 with an INA3221 wired to two rails (ch1 = 3.3 V nRF54L15 domain, ch2 = 5 V E22-900M30S domain, ch3 NC). After flashing, configuring channels + LoRa via the `meshtastic.org/e/` URL in the iOS app, and a 60 s broadcast interval, all six metrics show up correctly in Prometheus on the next daemon poll. Idle baseline measured: `ch1 = 3.32 V / 3.2 mA`, `ch2 = 4.91 V / 6.8 mA`; `ch3` reports zero as expected for an unwired channel.

Bug caught during dev: an earlier draft used `setdefault` which preserved the stale `deviceMetrics` from `nodesByNum` over the fresh pubsub copy — symptom was `meshtastic_uptime` freezing at the first-broadcast value. Final version uses override; uptime now ticks every cycle.

- [x] `python -c "import py_compile; py_compile.compile('scripts/meshmetricsd.py', doraise=True)"` clean
- [x] Daemon comes up clean against a serial-attached gateway
- [x] iOS pair + URL paste + 60 s poll interval shows `power_ch{1,2}_{voltage,current}` in Prometheus within one cycle
- [x] No regressions in existing `deviceMetrics` / `environmentMetrics` flow

## Future work (not in this PR)

- `localStats` variant is also dispatched via the same pubsub but not extracted — would benefit from the same treatment in a follow-up.
- The per-node push currently uses a single `job/instance` grouping on the pushgateway, so each push replaces the previous one. Per-node grouping (`/instance/<node_id>`) would let Prometheus see all nodes simultaneously without depending on scrape timing. Out of scope here.

Tested-by: cvaldess

🤖 Generated with [Claude Code](https://claude.com/claude-code)